### PR TITLE
Glue and paste Bokeh figures by HTML/JS output

### DIFF
--- a/myst_nb/__init__.py
+++ b/myst_nb/__init__.py
@@ -22,7 +22,7 @@ from sphinx.util.docutils import ReferenceRole, SphinxDirective
 
 from .exec_table import setup_exec_table
 from .execution import update_execution_cache
-from .nb_glue import glue, glue_bokeh  # noqa: F401
+from .nb_glue import glue  # noqa: F401
 from .nb_glue.domain import (
     NbGlueDomain,
     PasteInlineNode,

--- a/myst_nb/__init__.py
+++ b/myst_nb/__init__.py
@@ -22,7 +22,7 @@ from sphinx.util.docutils import ReferenceRole, SphinxDirective
 
 from .exec_table import setup_exec_table
 from .execution import update_execution_cache
-from .nb_glue import glue  # noqa: F401
+from .nb_glue import glue, glue_bokeh  # noqa: F401
 from .nb_glue.domain import (
     NbGlueDomain,
     PasteInlineNode,

--- a/myst_nb/nb_glue/__init__.py
+++ b/myst_nb/nb_glue/__init__.py
@@ -1,5 +1,5 @@
 import IPython
-from IPython.display import display as ipy_display
+from IPython.display import display as ipy_display, HTML, Javascript
 
 GLUE_PREFIX = "application/papermill.record/"
 
@@ -26,3 +26,17 @@ def glue(name, variable, display=True):
     ipy_display(
         {mime_prefix + k: v for k, v in mimebundle.items()}, raw=True, metadata=metadata
     )
+
+
+def glue_bokeh(name, figure, display=True):
+    # import here to avoid a hard dependency on bokeh
+    from bokeh.embed import components
+    from bokeh.resources import CDN
+    import xml.etree.ElementTree as ET
+
+    script, div = components(figure)
+    data = ET.fromstring(script).text
+    h = HTML(div)
+    s = Javascript(data, lib=CDN.js_files)
+    glue(name + "_js", s, display)
+    glue(name, h, display)

--- a/myst_nb/nb_glue/domain.py
+++ b/myst_nb/nb_glue/domain.py
@@ -218,7 +218,9 @@ class PasteFigure(Paste):
 class PasteBokeh(Paste):
     def run(self):
         html_node = PasteNode(self.arguments[0])
+        self.set_source_info(html_node)
         js_node = PasteNode(self.arguments[0] + "_js")
+        self.set_source_info(js_node)
         return [html_node, js_node]
 
 

--- a/myst_nb/nb_glue/domain.py
+++ b/myst_nb/nb_glue/domain.py
@@ -215,6 +215,13 @@ class PasteFigure(Paste):
         return [figure_node]
 
 
+class PasteBokeh(Paste):
+    def run(self):
+        html_node = PasteNode(self.arguments[0])
+        js_node = PasteNode(self.arguments[0] + "_js")
+        return [html_node, js_node]
+
+
 def paste_any_role(name, rawtext, text, lineno, inliner, options=None, content=()):
     """This role will simply add the cell output"""
     path = inliner.document.current_source
@@ -249,7 +256,7 @@ def paste_text_role(name, rawtext, text, lineno, inliner, options=None, content=
 
 
 class NbGlueDomain(Domain):
-    """A sphinx domain for handling glue data """
+    """A sphinx domain for handling glue data"""
 
     name = "glue"
     label = "NotebookGlue"
@@ -260,7 +267,13 @@ class NbGlueDomain(Domain):
     # - docmap is the mapping of docnames to the set of keys it contains
     initial_data = {"cache": {}, "docmap": {}}
 
-    directives = {"": Paste, "any": Paste, "figure": PasteFigure, "math": PasteMath}
+    directives = {
+        "": Paste,
+        "any": Paste,
+        "figure": PasteFigure,
+        "math": PasteMath,
+        "bokeh": PasteBokeh,
+    }
 
     roles = {"": paste_any_role, "any": paste_any_role, "text": paste_text_role}
 


### PR DESCRIPTION
This change adds the glue_bokeh function to insert the Bokeh figure
HTML and JS components into the cell output. The PasteBokeh handler then
collects the appropriate glued output and returns both nodes to be
included simultaneously.

The Bokeh figure components are returned as strings from the components
method, so they are converted to IPython HTML and Javascript objects
before being passed to glue() so that they have the correct mimetypes
for the display formatter. In addition, creating the Javascript object
allows us to add the BokehJS library dependency which will be injected
into the head of the HTML file.

This approach seems to be fairly robust, insofar as the figure is pasted
properly. It does not yet support being pasted as a MyST-NB Figure
though. Disadvantages of this approach, as I see them, are:

1) It requires a separate function to glue Bokeh figures, which isn't a
   super great UI, if it can be avoided
2) If a page has multiple pasted Bokeh figures, it isn't clear whether
   the BokehJS library will be injected into the header multiple times,
   and I'm not familiar enough with HTML semantics to know whether
   loading the same script multiple times is actually a problem.